### PR TITLE
Misc post open sourcing clean up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,6 @@
 name: CI
 
-on:
-  workflow_dispatch:
-    inputs:
-      force_release:
-        description: 'Force a release to run using the current version'
-        default: false
-        required: true
-        type: boolean
-  push:
-    branches:
-      - master
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   build:
@@ -61,15 +50,3 @@ jobs:
       env:
         BUNDLE_GEMFILE: ${{ matrix.gemfile }}
       run: bundle exec rake
-  publish:
-    needs: build
-    if: needs.build.result == 'success' && (github.event_name == 'push' || inputs.force_release)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - uses: Betterment/workflows/gem_release@gem_release-v6
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          betterment_gh_packages_pat: ${{ secrets.BETTERMENT_GH_PACKAGES_PAT }}
-          force: ${{ toJSON(inputs.force_release) }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # with_transactional_lock
 
-[![Build Status](https://travis-ci.com/Betterment/with_transactional_lock.svg?token=6b6DErRMUHX47kEoBZ3t&branch=master)](https://travis-ci.com/Betterment/with_transactional_lock)
-
 A simple extension to ActiveRecord for performing advisory locking on
 MySQL and PostgreSQL.
 


### PR DESCRIPTION
/task https://app.asana.com/0/1206330247396619/1206330443733025/f

This gets rid of the Travis badge in `README.md` and removes the publish step (and publish-related configuration) from the `ci.yml` file. 