### PR TITLE
Point gemspec to rubygems

### DIFF
--- a/with_transactional_lock.gemspec
+++ b/with_transactional_lock.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.summary     = "Transactional advisory locks for ActiveRecord"
   s.description = "Advisory locking support for MySQL and Postgresql done right."
   s.license     = "MIT"
-  s.metadata['allowed_push_host'] = 'https://rubygems.pkg.github.com/betterment'
+  s.metadata['allowed_push_host'] = 'https://rubygems.org'
   s.metadata['rubygems_mfa_required'] = 'true' # in case we ever use rubygems
 
   s.files = Dir["lib/**/*", "LICENSE", "Rakefile", "README.md"]


### PR DESCRIPTION
/task https://app.asana.com/0/1205835826533561/1205835897803467/f

This is no longer private and we intend to publish this in rubygems, so I updated `allowed_push_host` to be `rubygems.org`. I figure then we'll be able to `bundle exec rake release` and get 2.2.0. lmk if I'm missing any other steps!