### PR TITLE
feat: add lock name to SQL to trace the source

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,6 +206,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-22
   x86_64-linux
 
@@ -220,4 +221,4 @@ DEPENDENCIES
   with_transactional_lock!
 
 BUNDLED WITH
-   2.6.3
+   2.7.0

--- a/lib/with_transactional_lock/mixin.rb
+++ b/lib/with_transactional_lock/mixin.rb
@@ -59,8 +59,8 @@ module WithTransactionalLock
       private
 
       def acquire_lock
-        connection.execute("insert into transactional_advisory_locks values (#{connection.quote(db_lock_name)}) \
-        on duplicate key update lock_id = lock_id")
+        connection.execute("INSERT INTO transactional_advisory_locks VALUES (#{connection.quote(db_lock_name)}) \
+        ON DUPLICATE KEY UPDATE lock_id = lock_id")
       end
     end
 
@@ -68,7 +68,7 @@ module WithTransactionalLock
       private
 
       def acquire_lock
-        connection.execute("select pg_advisory_xact_lock(#{connection.quote(db_lock_name)})")
+        connection.execute("SELECT pg_advisory_xact_lock(#{connection.quote(db_lock_name)})")
       end
     end
   end

--- a/lib/with_transactional_lock/mixin.rb
+++ b/lib/with_transactional_lock/mixin.rb
@@ -68,7 +68,7 @@ module WithTransactionalLock
       private
 
       def acquire_lock
-        connection.execute("SELECT pg_advisory_xact_lock(#{connection.quote(db_lock_name)})")
+        connection.execute("/* lock:#{lock_name} */ SELECT pg_advisory_xact_lock(#{connection.quote(db_lock_name)})")
       end
     end
   end

--- a/lib/with_transactional_lock/version.rb
+++ b/lib/with_transactional_lock/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WithTransactionalLock
-  VERSION = "2.4.0"
+  VERSION = "2.4.1"
 end


### PR DESCRIPTION
### Summary


- [x] [chore: fix SQL keywords to be uppercase](https://github.com/Betterment/with_transactional_lock/pull/25/commits/c638e049a4a3d906b9d0da7c3d03b0eb648629bc)
- [x] [chore: update Gemfile.lock to use latest bundler version](https://github.com/Betterment/with_transactional_lock/pull/25/commits/0957992439a145a24397f55186f26e63200e741b)
- [x] [feat: add lock name to SQL to trace the source](https://github.com/Betterment/with_transactional_lock/pull/25/commits/c9c149ac3b60ff7948300a5577ed3528d8a42284)

### Description

This branch adds the lock name to the SQL to allow the original lock name to be traced.
