### PR TITLE
Add RBI file for Sorbet type support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project aims to adhere to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.2.1]
+
+### Added
+
+- Added support for Sorbet via an RBI file
+
 ## [3.2.0]
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    with_transactional_lock (3.2.0)
+    with_transactional_lock (3.2.1)
       activerecord (>= 7.2, < 8.2)
       railties (>= 7.2, < 8.2)
 
@@ -228,6 +228,7 @@ PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-darwin-22
   x86_64-linux
 

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    with_transactional_lock (3.2.0)
+    with_transactional_lock (3.2.1)
       activerecord (>= 7.2, < 8.2)
       railties (>= 7.2, < 8.2)
 

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    with_transactional_lock (3.2.0)
+    with_transactional_lock (3.2.1)
       activerecord (>= 7.2, < 8.2)
       railties (>= 7.2, < 8.2)
 

--- a/gemfiles/rails_8_1.gemfile.lock
+++ b/gemfiles/rails_8_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    with_transactional_lock (3.2.0)
+    with_transactional_lock (3.2.1)
       activerecord (>= 7.2, < 8.2)
       railties (>= 7.2, < 8.2)
 

--- a/lib/with_transactional_lock/version.rb
+++ b/lib/with_transactional_lock/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WithTransactionalLock
-  VERSION = "3.2.0"
+  VERSION = "3.2.1"
 end

--- a/rbi/with_transactional_lock.rbi
+++ b/rbi/with_transactional_lock.rbi
@@ -1,0 +1,11 @@
+# typed: strong
+# frozen_string_literal: true
+
+module WithTransactionalLock::Mixin::ClassMethods
+  sig do
+    type_parameters(:U)
+      .params(lock_name: String, block: T.proc.returns(T.type_parameter(:U)))
+      .returns(T.type_parameter(:U))
+  end
+  def with_transactional_lock(lock_name, &block); end
+end

--- a/with_transactional_lock.gemspec
+++ b/with_transactional_lock.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.metadata['allowed_push_host'] = 'https://rubygems.org'
   s.metadata['rubygems_mfa_required'] = 'true' # in case we ever use rubygems
 
-  s.files = Dir["lib/**/*", "LICENSE", "Rakefile", "README.md"]
+  s.files = Dir["lib/**/*", "rbi/**/*", "LICENSE", "Rakefile", "README.md"]
 
   rails_constraints = ['>= 7.2', '< 8.2']
 


### PR DESCRIPTION
This PR adds an [RBI file](https://sorbet.org/docs/rbi#rbis-within-gems) so that consumers of this gem that use Sorbet get full type support.